### PR TITLE
fix for logout callback error

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -17,9 +17,12 @@ router.get('/oauth2callback', passport.authenticate("google",{
 );
 
 //logout router
-router.get("/logout", (req,res)=> {
-    req.logout();
-    res.redirect("/");
+router.get("/logout", (req,res, next)=> {
+    req.logout(function(err){
+        if(err){
+            return next(err);  }
+            res.redirect("/");
+    })
 })
 
 module.exports = router,


### PR DESCRIPTION
did some research and discovered with a new release of passport req.logout() is now an asynchronous function
https://stackoverflow.com/questions/72336177/error-reqlogout-requires-a-callback-function

Passport docs also had an example
(https://www.passportjs.org/concepts/authentication/logout/)